### PR TITLE
Refactoring to use the Reapply effect

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ include(FetchContent)
 FetchContent_Declare(
   trieste
   GIT_REPOSITORY https://github.com/microsoft/Trieste
-  GIT_TAG f5874e6f014bd9b7deabd90f8d49afa1aa1332bf
+  GIT_TAG ca619ecf072a87ebe6351fc437964573eed2b23f
   )
 
 FetchContent_MakeAvailable(trieste)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ include(FetchContent)
 FetchContent_Declare(
   trieste
   GIT_REPOSITORY https://github.com/microsoft/Trieste
-  GIT_TAG 467157a167d2e929095498089f29fc9419f4ef11     
+  GIT_TAG f5874e6f014bd9b7deabd90f8d49afa1aa1332bf
   )
 
 FetchContent_MakeAvailable(trieste)

--- a/src/miniml-lang.hh
+++ b/src/miniml-lang.hh
@@ -7,30 +7,33 @@ namespace miniml
 
   // Program
   inline const auto Program = TokenDef("program", flag::symtab | flag::defbeforeuse);
-  // Declarations 
-  inline const auto Let = TokenDef("let", flag::lookup); 
-  
-  // --- Types --- 
+  // Declarations
+  inline const auto Let = TokenDef("let", flag::lookup);
+
+  // --- Types ---
   inline const auto Type = TokenDef("type");
   inline const auto TNone = TokenDef("none");
   inline const auto TInt = TokenDef("t_int");
   inline const auto TBool = TokenDef("t_bool");
   inline const auto TVar = TokenDef("t_var", flag::print);
   inline const auto TypeArrow = TokenDef("->");
-  // Constructed types 
+  // Constructed types
   inline const auto TVars = TokenDef("t_vars");
   inline const auto ForAllTy = TokenDef("forall");
-  //Constraints 
+  //Constraints
   inline const auto EqConstr = TokenDef("eq_constraint", flag::lookup);
   inline const auto InstConstr = TokenDef("inst_constraint", flag::lookup);
   inline const auto GenConstr = TokenDef("gen_constraint", flag::lookup);
+  inline const auto SubstEqConstr = TokenDef("subst_eq_constraint");
+  inline const auto SubstInstConstr = TokenDef("subst_inst_constraint");
+  inline const auto SubstGenConstr = TokenDef("subst_gen_constraint");
   inline const auto Constraints = TokenDef("constraints");
-  //Type Error 
-  inline const auto TypError = TokenDef("typeerror"); 
+  //Type Error
+  inline const auto TypError = TokenDef("typeerror");
 
-  // --- Expressions --- 
+  // --- Expressions ---
 
-  // Constants 
+  // Constants
   inline const auto Int = TokenDef("int", flag::print);
   inline const auto True = TokenDef("true");
   inline const auto False = TokenDef("false");
@@ -43,40 +46,45 @@ namespace miniml
 
   // Comparison expressions
   inline const auto LT = TokenDef("<");
-  inline const auto Equals = TokenDef("=");  
+  inline const auto Equals = TokenDef("=");
 
-  // Functions 
+  // Functions
   inline const auto Fun  = TokenDef("fun", flag::symtab); //binds its argument to its symtab
-  inline const auto FunDef = TokenDef("fundef", flag::lookup | flag::shadowing); 
-  inline const auto Param = TokenDef("param", flag::lookup | flag::shadowing); 
+  inline const auto FunDef = TokenDef("fundef", flag::lookup | flag::shadowing);
+  inline const auto Param = TokenDef("param", flag::lookup | flag::shadowing);
   inline const auto Annotation = TokenDef("t_annotation");
   inline const auto Is  = TokenDef("is");
 
-  // Constants 
+  // Constants
   inline const auto If = TokenDef("if");
   inline const auto Then = TokenDef("then");
-  inline const auto Else = TokenDef("else"); 
-  
-  // Identifiers 
-  inline const auto Ident = TokenDef("ident", flag::print); 
+  inline const auto Else = TokenDef("else");
 
-  // Grouping tokens 
+  // Identifiers
+  inline const auto Ident = TokenDef("ident", flag::print);
+
+  // Grouping tokens
   inline const auto TopExpr = TokenDef("topexpr"); // expressions/let decl at top level
   inline const auto Expr = TokenDef("expr");
-  inline const auto App = TokenDef("app"); // function application 
-  
-  // Separators 
+  inline const auto App = TokenDef("app"); // function application
+
+  // Separators
   inline const auto Colon = TokenDef(":");
   inline const auto Term = TokenDef(";;");
   inline const auto Paren = TokenDef("()");
 
-  // Convenience tokens 
-  inline const auto Name = TokenDef("name", flag::print); 
+  // Convenience tokens
+  inline const auto Name = TokenDef("name", flag::print);
   inline const auto Op = TokenDef("op");
   inline const auto Lhs = TokenDef("lhs");
   inline const auto Rhs = TokenDef("rhs");
   inline const auto Ty1 = TokenDef("ty1");
-  inline const auto Ty2 = TokenDef("ty2"); 
+  inline const auto Ty11 = TokenDef("ty11");
+  inline const auto Ty12 = TokenDef("ty12");
+  inline const auto Ty2 = TokenDef("ty2");
+  inline const auto Ty21 = TokenDef("ty21");
+  inline const auto Ty22 = TokenDef("ty22");
+  inline const auto Constr = TokenDef("constraint");
 
 
 }

--- a/src/miniml-lang.hh
+++ b/src/miniml-lang.hh
@@ -21,15 +21,13 @@ namespace miniml
   inline const auto TVars = TokenDef("t_vars");
   inline const auto ForAllTy = TokenDef("forall");
   //Constraints
-  inline const auto EqConstr = TokenDef("eq_constraint", flag::lookup);
-  inline const auto InstConstr = TokenDef("inst_constraint", flag::lookup);
-  inline const auto GenConstr = TokenDef("gen_constraint", flag::lookup);
+  inline const auto EqConstr = TokenDef("eq_constraint");
+  inline const auto InstConstr = TokenDef("inst_constraint");
+  inline const auto GenConstr = TokenDef("gen_constraint");
   inline const auto SubstEqConstr = TokenDef("subst_eq_constraint");
   inline const auto SubstInstConstr = TokenDef("subst_inst_constraint");
   inline const auto SubstGenConstr = TokenDef("subst_gen_constraint");
   inline const auto Constraints = TokenDef("constraints");
-  //Type Error
-  inline const auto TypError = TokenDef("typeerror");
 
   // --- Expressions ---
 

--- a/src/passes/internal.hh
+++ b/src/passes/internal.hh
@@ -146,11 +146,14 @@ namespace miniml{
     | (InstConstr <<= (Ty1 >>= TVar) * (Ty2 >>= TVar)) // Ty1 is an instance of Ty2
     | (Expr <<= Type * (Expr >>= wf_expr));
 
+    // Constraints empty
     inline const auto wf_solve_constr =
-    wf_inf_exprs
+    wf_fresh
+    | (Expr <<= Type * (Expr >>= wf_expr))
     | (ForAllTy <<= TVars * Type)
     | (TVars <<= TVar++)
-    | (Program <<= (Let | Expr)++)
+    | (Program <<= TopExpr++)
+    | (TopExpr <<= Constraints * (Expr >>= (Let | Expr)))
     | (Type <<= (Type >>= wf_types | ForAllTy))
     | (Let <<= Ident * Type * Expr) // remove binding to reduce clutter
     | (Param <<= Ident * Type) // remove binding to reduce clutter                                                                                                                                                                                                                                                                                                      // remove binding to reduce clutter
@@ -161,16 +164,10 @@ namespace miniml{
 
     // Final Wf
     // TODO: Finish, base on wf from parse namespace
-    inline const auto wf =
-    (Top <<= Program)
+    inline const auto wf_cleanup_constr =
+    wf_solve_constr
     | (Program <<= (Let | Expr)++)
-    | (Expr <<= Type * (Expr >>= wf_expr))
-    | (Let <<= Ident * Type * Expr) //remove binding to reduce clutter
-    | (Param <<= Ident * Type) //remove binding to reduce clutter
-    | (FunDef <<= Ident * Type * Param * Expr) //remove binding to reduce clutter
-    | (Type <<= (Type >>= wf_types | ForAllTy))
-    | (ForAllTy <<= TVars * Type)
-    | (TVars <<= TVar++);
+    ;
 
     }
 

--- a/src/passes/internal.hh
+++ b/src/passes/internal.hh
@@ -144,32 +144,29 @@ namespace miniml{
     | (Constraints <<= (EqConstr | InstConstr | GenConstr)++)
     | (GenConstr <<= (Ty1 >>= TVar) * (Ty2 >>= wf_types)) // Ty1 is a generalization of Ty2
     | (InstConstr <<= (Ty1 >>= TVar) * (Ty2 >>= TVar)) // Ty1 is an instance of Ty2
-    | (Expr <<= Type * (Expr >>= wf_expr));
-
-    // Constraints empty
-    inline const auto wf_solve_constr =
-    wf_fresh
     | (Expr <<= Type * (Expr >>= wf_expr))
-    | (ForAllTy <<= TVars * Type)
-    | (TVars <<= TVar++)
-    | (Program <<= TopExpr++)
-    | (TopExpr <<= Constraints * (Expr >>= (Let | Expr)))
-    | (Type <<= (Type >>= wf_types | ForAllTy))
-    | (Let <<= Ident * Type * Expr) // remove binding to reduce clutter
-    | (Param <<= Ident * Type) // remove binding to reduce clutter                                                                                                                                                                                                                                                                                                      // remove binding to reduce clutter
-    | (FunDef <<= Ident * Type * Param * Expr) // remove binding to reduce clutter                                                                                                                                                                                                                                                                                     // remove binding to reduce clutter
     ;
 
-    // TODO: wf for pass that does cleanup
+    inline const auto wf_solve_constr =
+    wf_inf_exprs
+    | (Type <<= (Type >>= wf_types | ForAllTy))
+    | (ForAllTy <<= TVars * Type)
+    | (TVars <<= TVar++)
+    | (Constraints <<= trieste::wf::Fields({}, Invalid))
+    ;
 
     // Final Wf
-    // TODO: Finish, base on wf from parse namespace
-    inline const auto wf_cleanup_constr =
-    wf_solve_constr
-    | (Program <<= (Let | Expr)++)
+    inline const auto wf =
+    parse::wf
+    | (Type <<= (Type >>= wf_types | ForAllTy))
+    | (ForAllTy <<= TVars * Type)
+    | (TVars <<= TVar++)
+    | (Let <<= Ident * Type * Expr)
+    | (Expr <<= Type * (Expr >>= wf_expr))
+    | (Param <<= Ident * Type)
+    | (FunDef <<= Ident * Type * Param * Expr)
     ;
 
     }
-
 }
 

--- a/src/passes/internal.hh
+++ b/src/passes/internal.hh
@@ -142,7 +142,7 @@ namespace miniml{
 
     inline const auto wf_inf_exprs = wf_fresh
     | (Constraints <<= (EqConstr | InstConstr | GenConstr)++)
-    | (GenConstr <<= (Ty1 >>= wf_types) * (Ty2 >>= wf_types)) //Ty is a generalization of Ty2
+    | (GenConstr <<= (Ty1 >>= TVar) * (Ty2 >>= wf_types)) // Ty1 is a generalization of Ty2
     | (InstConstr <<= (Ty1 >>= TVar) * (Ty2 >>= TVar)) // Ty1 is an instance of Ty2
     | (Expr <<= Type * (Expr >>= wf_expr));
 

--- a/src/passes/internal.hh
+++ b/src/passes/internal.hh
@@ -133,9 +133,9 @@ namespace miniml{
     inline const auto wf_fresh = parse::wf
     | (TopExpr <<= Constraints * (Expr >>= (Let | Expr)))
     | (Constraints <<= EqConstr++)
+    | (EqConstr <<= (Ty1 >>= wf_types) * (Ty2 >>= wf_types))
     | (Param <<= Ident * Type)[Ident] // bind fun arguments to symtab
     | (Let <<= Ident * Type * Expr)[Ident] // bind let variable to symtab
-    | (EqConstr <<= (Ty1 >>= wf_types) * (Ty2 >>= wf_types))
     | (Type <<= (Type >>= wf_types))
     | (FunDef <<= Ident * Type * Param * Expr)[Ident] // to access nested functions
     ;
@@ -148,11 +148,10 @@ namespace miniml{
     ;
 
     inline const auto wf_solve_constr =
-    wf_inf_exprs
+    (wf_inf_exprs - Constraints - EqConstr - GenConstr - InstConstr)
     | (Type <<= (Type >>= wf_types | ForAllTy))
     | (ForAllTy <<= TVars * Type)
     | (TVars <<= TVar++)
-    | (Constraints <<= trieste::wf::Fields({}, Invalid))
     ;
 
     // Final Wf

--- a/src/passes/internal.hh
+++ b/src/passes/internal.hh
@@ -2,12 +2,12 @@
 #include "../miniml-lang.hh"
 
 namespace miniml{
- using namespace trieste;  
+ using namespace trieste;
 
     std::vector<Pass> passes();
 
-    inline const auto wf_types = TInt | TBool | TVar | TypeArrow ; 
-    inline const auto wf_expr = Int | True | False 
+    inline const auto wf_types = TInt | TBool | TVar | TypeArrow ;
+    inline const auto wf_expr = Int | True | False
     | Add | Sub | Mul | LT | Equals
     | If | Ident | Fun | App ;
 
@@ -15,19 +15,19 @@ namespace miniml{
 
     Parse parser();
 
-    inline const auto wf_parse_tokens = 
-     Add | Sub | Mul | 
+    inline const auto wf_parse_tokens =
+     Add | Sub | Mul |
      Equals | LT |
-     Int | True | False | 
+     Int | True | False |
      If | Then | Else |
-     Ident | Fun | Is | Let | 
-     Colon | Paren | Term | 
+     Ident | Fun | Is | Let |
+     Colon | Paren | Term |
      wf_types
      ;
-    
+
     inline const wf::Wellformed wf =
       (Top <<= File)
-    | (File <<= (Term | Group)) 
+    | (File <<= (Term | Group))
     | (Paren <<= Group)
     | (Term <<= (Group)++[1])
     | (Group <<= (wf_parse_tokens)++[1])
@@ -36,16 +36,16 @@ namespace miniml{
     }
     namespace parse{
 
-    inline const auto wf_parse_cleanup = init_parse::wf 
-    | (Top <<= Program) 
+    inline const auto wf_parse_cleanup = init_parse::wf
+    | (Top <<= Program)
     | (Program <<= (Group)++)
     ;
 
-    inline const auto wf_exp_tokens_fun = init_parse::wf_parse_tokens 
+    inline const auto wf_exp_tokens_fun = init_parse::wf_parse_tokens
         - (wf_types | Is | Let | Colon | Term);
 
     inline const auto wf_group_tokens = (init_parse::wf_parse_tokens | Expr)
-        - (wf_types | Colon | Is | Fun); 
+        - (wf_types | Colon | Is | Fun);
 
     inline const auto wf_fun =
       wf_parse_cleanup
@@ -53,25 +53,25 @@ namespace miniml{
     | (FunDef <<= Ident * Annotation * Param * Expr)
     | (Annotation <<= Type >>= (wf_types | TNone))
     | (TypeArrow <<= (Ty1 >>= wf_types) * (Ty2 >>= wf_types))
-    | (Param <<= Ident * Annotation)  
+    | (Param <<= Ident * Annotation)
     | (Expr <<= (wf_exp_tokens_fun)++[1])
     | (Group <<= (wf_group_tokens)++[1])
     ;
-    inline const auto wf_exp_tokens_par = (wf_exp_tokens_fun | Expr) - Paren; 
-  
+    inline const auto wf_exp_tokens_par = (wf_exp_tokens_fun | Expr) - Paren;
+
     inline const auto wf_parens =
-    wf_fun 
+    wf_fun
     | (Expr <<= (wf_exp_tokens_par)++[1])
     | (Group <<= ((wf_group_tokens | Let) - Paren)++[1])
     ;
     inline const auto wf_let =
       wf_parens
-    | (Program <<= TopExpr++) 
+    | (Program <<= TopExpr++)
     | (TopExpr <<= (Let | Expr))
     | (Let <<= Ident * Expr)
     | (Expr <<= (wf_exp_tokens_par)++[1])
     ;
-    inline const auto wf_exp_tokens_cond = wf_exp_tokens_par - Then - Else; 
+    inline const auto wf_exp_tokens_cond = wf_exp_tokens_par - Then - Else;
 
     inline const auto wf_conditionals =
       wf_let
@@ -80,21 +80,21 @@ namespace miniml{
     ;
 
     inline const auto wf_exp_tokens_app =
-      wf_exp_tokens_cond | App; 
+      wf_exp_tokens_cond | App;
 
     inline const auto wf_funapp =
       wf_conditionals
-    | (Expr <<= wf_exp_tokens_app++[1]) 
+    | (Expr <<= wf_exp_tokens_app++[1])
     | (App <<= (Lhs >>= Expr) * (Rhs >>= Expr))
     ;
-      
+
     inline const auto wf_mul =
       wf_funapp
     | (Mul <<= (Lhs >>= Expr) * (Rhs >>= Expr))
     ;
 
     inline const auto wf_add =
-      wf_mul 
+      wf_mul
     | (Add <<= (Lhs >>= Expr) * (Rhs >>= Expr))
     | (Sub <<= (Lhs >>= Expr) * (Rhs >>= Expr))
     ;
@@ -102,26 +102,26 @@ namespace miniml{
     inline const auto wf_cmp =
       wf_add
     | (LT <<= (Lhs >>= Expr) * (Rhs >>= Expr))
-    | (Equals <<= (Lhs >>= Expr) * (Rhs >>= Expr)) 
-    ; 
+    | (Equals <<= (Lhs >>= Expr) * (Rhs >>= Expr))
+    ;
 
     // Final WF
-    inline const wf::Wellformed wf = 
+    inline const wf::Wellformed wf =
     (Top <<= Program)
-    | (Program <<= TopExpr++) 
+    | (Program <<= TopExpr++)
     | (TopExpr <<= (Let | Expr))
     | (Let <<= Ident * Expr)
     | (Expr <<= wf_expr)
     | (If <<= Expr * Expr * Expr)
     | (Fun <<= FunDef)
     | (FunDef <<= Ident * Annotation * Param * Expr)[Ident]
-    | (Param <<= Ident * Annotation)  
+    | (Param <<= Ident * Annotation)
     | (App <<= (Lhs >>= Expr) * (Rhs >>= Expr))
     | (Mul <<= (Lhs >>= Expr) * (Rhs >>= Expr))
     | (Add <<= (Lhs >>= Expr) * (Rhs >>= Expr))
     | (Sub <<= (Lhs >>= Expr) * (Rhs >>= Expr))
     | (LT <<= (Lhs >>= Expr) * (Rhs >>= Expr))
-    | (Equals <<= (Lhs >>= Expr) * (Rhs >>= Expr)) 
+    | (Equals <<= (Lhs >>= Expr) * (Rhs >>= Expr))
     | (Annotation <<= Type >>= (wf_types | TNone))
     | (TypeArrow <<= (Ty1 >>= wf_types) * (Ty2 >>= wf_types))
     ;
@@ -130,36 +130,39 @@ namespace miniml{
 
     namespace check{
 
-    inline const auto wf_fresh = parse::wf 
-    | (TopExpr <<= Constraints * (Expr >>= (Let | Expr))) 
-    | (Constraints <<= (EqConstr | InstConstr | GenConstr)++) 
+    inline const auto wf_fresh = parse::wf
+    | (TopExpr <<= Constraints * (Expr >>= (Let | Expr)))
+    | (Constraints <<= (EqConstr | InstConstr | GenConstr)++)
     | (Param <<= Ident * Type)[Ident] // bind fun arguments to symtab
     | (Let <<= Ident * Type * Expr)[Ident] // bind let variable to symtab
-    | (EqConstr <<= (Ty1 >>= wf_types) * (Ty2 >>= wf_types)) 
+    | (EqConstr <<= (Ty1 >>= wf_types) * (Ty2 >>= wf_types))
     | (InstConstr <<= (Ty1 >>= wf_types) * (Ty2 >>= TVar)) // Ty1 is an instance of Ty2
     | (GenConstr <<= (Ty1 >>= wf_types) * (Ty2 >>= wf_types)) //Ty is a generalization of Ty2
-    | (Type <<= (Type >>= wf_types)) 
-    | (FunDef <<= Ident * Type * Param * Expr)[Ident] // to access nested functions
     | (Type <<= (Type >>= wf_types))
+    | (FunDef <<= Ident * Type * Param * Expr)[Ident] // to access nested functions
     ;
 
-    inline const auto wf_inf_exprs = wf_fresh 
+    inline const auto wf_inf_exprs = wf_fresh
     | (Expr <<= Type * (Expr >>= wf_expr));
 
     inline const auto wf_solve_constr =
-    wf_inf_exprs 
-    | (ForAllTy <<= TVars * Type) 
-    | (TVars <<= TVar++) 
+    wf_inf_exprs
+    | (ForAllTy <<= TVars * Type)
+    | (TVars <<= TVar++)
     | (Program <<= (Let | Expr)++)
-    | (Type <<= (Type >>= wf_types | ForAllTy)) 
+    | (Type <<= (Type >>= wf_types | ForAllTy))
     | (Let <<= Ident * Type * Expr) // remove binding to reduce clutter
     | (Param <<= Ident * Type) // remove binding to reduce clutter                                                                                                                                                                                                                                                                                                      // remove binding to reduce clutter
     | (FunDef <<= Ident * Type * Param * Expr) // remove binding to reduce clutter                                                                                                                                                                                                                                                                                     // remove binding to reduce clutter
     ;
 
+    // TODO: wf for pass that does cleanup
+
     // Final Wf
-    inline const auto wf = 
-    (Program <<= (Let | Expr)++)
+    // TODO: Finish, base on wf from parse namespace
+    inline const auto wf =
+    (Top <<= Program)
+    | (Program <<= (Let | Expr)++)
     | (Expr <<= Type * (Expr >>= wf_expr))
     | (Let <<= Ident * Type * Expr) //remove binding to reduce clutter
     | (Param <<= Ident * Type) //remove binding to reduce clutter
@@ -171,5 +174,4 @@ namespace miniml{
     }
 
 }
-  
-   
+

--- a/src/passes/internal.hh
+++ b/src/passes/internal.hh
@@ -132,17 +132,18 @@ namespace miniml{
 
     inline const auto wf_fresh = parse::wf
     | (TopExpr <<= Constraints * (Expr >>= (Let | Expr)))
-    | (Constraints <<= (EqConstr | InstConstr | GenConstr)++)
+    | (Constraints <<= EqConstr++)
     | (Param <<= Ident * Type)[Ident] // bind fun arguments to symtab
     | (Let <<= Ident * Type * Expr)[Ident] // bind let variable to symtab
     | (EqConstr <<= (Ty1 >>= wf_types) * (Ty2 >>= wf_types))
-    | (InstConstr <<= (Ty1 >>= wf_types) * (Ty2 >>= TVar)) // Ty1 is an instance of Ty2
-    | (GenConstr <<= (Ty1 >>= wf_types) * (Ty2 >>= wf_types)) //Ty is a generalization of Ty2
     | (Type <<= (Type >>= wf_types))
     | (FunDef <<= Ident * Type * Param * Expr)[Ident] // to access nested functions
     ;
 
     inline const auto wf_inf_exprs = wf_fresh
+    | (Constraints <<= (EqConstr | InstConstr | GenConstr)++)
+    | (GenConstr <<= (Ty1 >>= wf_types) * (Ty2 >>= wf_types)) //Ty is a generalization of Ty2
+    | (InstConstr <<= (Ty1 >>= TVar) * (Ty2 >>= TVar)) // Ty1 is an instance of Ty2
     | (Expr <<= Type * (Expr >>= wf_expr));
 
     inline const auto wf_solve_constr =

--- a/src/passes/passes.cc
+++ b/src/passes/passes.cc
@@ -30,6 +30,7 @@ std::vector<Pass> passes(){
       inf_exprs(),
       let_constr(),
       solve_constraints(),
+      cleanup_constraints(),
       };
-    } 
+    }
 }

--- a/src/passes/typecheck/inference.cc
+++ b/src/passes/typecheck/inference.cc
@@ -1,7 +1,7 @@
 #include "../internal.hh"
 #include "../utils.hh"
 
-//Infer types and constraints 
+//Infer types and constraints
 
 namespace miniml
 {
@@ -141,10 +141,10 @@ namespace miniml
                   auto r_typ = _(Rhs) / Type;
                   auto op_eqconstraint = eq_constraint(l_typ, r_typ, _(Expr));
                   auto expr = (Expr << (Type << optyp) << _(Op));
-                  return (_(Op)->type() == Equals) 
+                  return (_(Op)->type() == Equals)
                     ? Seq << (lift_constraint(op_eqconstraint)) << expr
                     : Seq << (lift_constraints({op_eqconstraint, eq_constraint(r_typ, int_type(), _(Expr))}))
-                          << expr;  
+                          << expr;
                 },
             // FUNDEF
             T(Expr) << (T(Fun)[Fun]
@@ -179,7 +179,7 @@ namespace miniml
                                << expr;
                   }
                   else if (lhs_typ->type() == TVar)
-                  { 
+                  {
                     auto fun_typ = arrow_type(rhs_typ, ret_typ);
                     auto fun_constraint = eq_constraint(lhs_typ, fun_typ, _(App));
                     return Seq << lift_constraint(fun_constraint)
@@ -219,6 +219,9 @@ namespace miniml
          {
            auto let_typ = get_type(_(Let));
            auto rhs_typ = get_type(_(Let) / Expr);
+           if (let_typ->type() != TVar) {
+             return err(_(Let), "Internal error: let binding has non-variable type");
+           }
            auto constr = gen_constraint(let_typ, rhs_typ, _(Let));
            return Seq << (_(Constraints) << constr)
                       << _(Let);

--- a/src/passes/typecheck/solve_constraints.cc
+++ b/src/passes/typecheck/solve_constraints.cc
@@ -35,8 +35,8 @@ namespace miniml
             ((T(TypeArrow) << (type[Ty11] * type[Ty12])) *
              (T(TypeArrow) << (type[Ty21] * type[Ty22]))) >>
           [](Match& _) {
-              auto c1 = (SubstEqConstr ^ _(EqConstr)) << _(Ty11) << _(Ty21);
-              auto c2 = (SubstEqConstr ^ _(EqConstr)) << _(Ty21) << _(Ty22);
+              auto c1 = (EqConstr ^ _(EqConstr)) << _(Ty11) << _(Ty21);
+              auto c2 = (EqConstr ^ _(EqConstr)) << _(Ty12) << _(Ty22);
               return Reapply << c1 << c2;
           },
 

--- a/src/passes/typecheck/solve_constraints.cc
+++ b/src/passes/typecheck/solve_constraints.cc
@@ -84,10 +84,10 @@ namespace miniml
           [local_subst](Match& _) -> Node {
             auto res = local_subst->find(node_val(_(TVar)));
             if (res != local_subst->end()){
-              return (res->second)->clone();
+              return res->second->clone();
             }
-            // TODO: This is dropped?
-            return err(_(TVar), "Internal error: no substitution found for type variable");
+            // TODO: Should check if this is an unbound variable and report an internal error
+            return NoChange;
         },
 
         // errors
@@ -103,7 +103,6 @@ namespace miniml
   // TODO: Pass that replaces TopExpr by its Expr (wf is wf). Replace TypError above with regular Errors
 
   // clean-up after pass
-  // TODO: See if this can be done as a post instead
   tc.post([](Node n){
       auto program = n->front();
       for(auto ts = program->begin(); ts != program->end(); ts++){

--- a/src/passes/typecheck/solve_constraints.cc
+++ b/src/passes/typecheck/solve_constraints.cc
@@ -109,7 +109,7 @@ namespace miniml
     return {
         "cleanup_constraints",
         check::wf,
-        dir::once | dir::bottomup,
+        dir::topdown | dir::once,
         {
           T(Constraints) >>
             [](Match&) { return nothing; },

--- a/src/passes/typecheck/solve_constraints.cc
+++ b/src/passes/typecheck/solve_constraints.cc
@@ -7,111 +7,123 @@ namespace miniml
   using namespace trieste;
   using namespace wf::ops;
 
-  inline const Node nothing = {}; 
+  inline const Node nothing = {};
 
-  // solve constraints and substitute types 
+  // solve constraints and substitute types
   PassDef solve_constraints()
   {
     std::shared_ptr<Subst> global_subst = std::make_shared<Subst>();
     std::shared_ptr<Subst> local_subst = std::make_shared<Subst>();
+
     PassDef tc = {
       "solve_constraints",
       check::wf_solve_constr,
-      (dir::topdown),
+      dir::topdown | dir::once,
       {
-        T(EqConstr)[EqConstr] << (type[Ty1] * type[Ty2]) >> 
-          [local_subst](Match& _){
-            auto constr = _(EqConstr);
-            auto source_str = node_val(constr);
-            auto constr_updated = apply_subst(local_subst,constr); 
-            auto t1 = constr/Ty1; auto t2 = constr/Ty2;
-            if (t1->type() == TVar){
-              if(in_type(node_val(t1),t2)){ //if type variable t1 is used inside t2 
-                return (TypError ^ source_str) << t1 << t2;
-              } else if (node_val(t1) == node_val(t2)){
-                return nothing;
-              } 
-              update_substmap(local_subst, t1, t2, source_str);
+        // Start by substituting the constraint, regardless of the type
+        T(EqConstr, InstConstr, GenConstr)[Constr] << (type[Ty1] * type[Ty2]) >>
+          [local_subst](Match& _) {
+            subst_type(_(Ty1), local_subst);
+            subst_type(_(Ty2), local_subst);
+            auto constr = (_(Constr)->type() == EqConstr? SubstEqConstr:
+                           _(Constr)->type() == InstConstr? SubstInstConstr:
+                           SubstGenConstr) ^ _(Constr);
+            return Reapply << (constr << _(Ty1) << _(Ty2));
+          },
+
+        T(SubstEqConstr)[EqConstr] <<
+            ((T(TypeArrow) << (type[Ty11] * type[Ty12])) *
+             (T(TypeArrow) << (type[Ty21] * type[Ty22]))) >>
+          [](Match& _) {
+              auto c1 = (SubstEqConstr ^ _(EqConstr)) << _(Ty11) << _(Ty21);
+              auto c2 = (SubstEqConstr ^ _(EqConstr)) << _(Ty21) << _(Ty22);
+              return Reapply << c1 << c2;
+          },
+
+        T(SubstEqConstr)[EqConstr] << ((T(TVar)[TVar] * type[Type]) /
+                                       (type[Type] * T(TVar)[TVar])) >>
+          [local_subst](Match& _) {
+            // TODO: source_str is not needed in substmap anymore!
+            auto source_str = node_val(_(EqConstr));
+            if(in_type(node_val(_(TVar)), _(Type))) {
+                return (TypError ^ _(EqConstr)) << _(TVar) << _(Type);
             }
-            else if (t2->type() == TVar)
-            {
-              if(in_type(node_val(t2),t1)){ //if type variable t2 is used inside t1
-                return (TypError ^ source_str) << t2 << t1;
-              } else if (node_val(t1) == node_val(t2)){
-                return nothing;
+            update_substmap(local_subst, _(TVar), _(Type), source_str);
+            return nothing;
+          },
+
+        T(SubstEqConstr)[EqConstr] << (type[Ty1] * type[Ty2]) >>
+          [](Match& _) {
+              if (_(Ty1)->type() != _(Ty2)->type()) {
+                return (TypError ^ _(EqConstr)) << _(Ty1) << _(Ty2);
               }
-              update_substmap(local_subst, t2, t1, source_str);
-            }
-            else if (t1->type() == TypeArrow && t2->type() == TypeArrow)
-            {
-              auto c1 = eq_constraint(t1 / Ty1, t2 / Ty1, source_str);
-              auto c2 = eq_constraint(t1 / Ty2, t2 / Ty2, source_str);
-              return Seq << c1 << c2; 
-            }
-            else if (t1->type() != t2->type())
-            {
-              return (TypError ^ source_str) << t1 << t2;
-            }
-            return (constr_updated) ? constr : nothing; //return updated constraint to view next 
-            
-        },
-        T(InstConstr)[InstConstr] << (type[Ty1] * T(TVar)[Ty2])  >>
+              return nothing;
+          },
+
+        // TODO: Ty1 can only be a type variable
+        T(SubstInstConstr)[InstConstr] << (type[Ty1] * T(TVar)[TVar])  >>
         [local_subst, global_subst](Match& _){
-            auto constr = _(InstConstr);
-            apply_subst(local_subst,constr);
-            auto t1 = constr/Ty1; auto t2 = constr/Ty2;
-            auto res = global_subst->find(node_val(t2));
+            auto res = global_subst->find(node_val(_(TVar)));
             if (res != global_subst->end()){
-              auto typ = instantiate((res->second.first));
-              update_substmap(local_subst, t1, typ, node_val(constr)); 
-              return eq_constraint(t1, typ, node_val(constr)); //return updated constraint to view next 
+              auto typ = instantiate(res->second.first);
+              update_substmap(local_subst, _(Ty1), typ, node_val(_(InstConstr)));
+              return Reapply << ((SubstEqConstr ^ _(InstConstr)) << _(Ty1) << typ); //return updated constraint to view next
             }
-            else
-              return err(t2,"internal error, could not find type");
-        }, 
-        T(GenConstr)[GenConstr] << (type[Ty1] * type[Ty2]) >>
+            // TODO: This will be dropped?
+            else {
+              return err(_(TVar), "internal error, could not find type");
+            }
+        },
+
+        // TODO: Ty1 is a type variable
+        T(SubstGenConstr)[GenConstr] << (type[Ty1] * type[Ty2]) >>
         [local_subst, global_subst](Match& _){
-            auto constr = _(GenConstr);
-            apply_subst(local_subst,constr);
-            auto t1 = constr/Ty1; auto t2 = constr/Ty2;
-            auto typ = generalize(t2);
+            auto typ = generalize(_(Ty2));
             // add to global substitution
-            (*global_subst)[node_val(t1)] = std::make_pair(typ, node_val(_(GenConstr)));
-            update_substmap(local_subst, t1, typ, node_val(constr));  // update local subst
+            (*global_subst)[node_val(_(Ty1))] = std::make_pair(typ, node_val(_(GenConstr)));
+            update_substmap(local_subst, _(Ty1), typ, node_val(_(GenConstr)));  // update local subst
             return nothing;
         },
-        // substitute types 
+
+        // substitute types
         In(Let,Expr,TypError)++ * (T(TVar)[TVar]) >>
-          [local_subst](Match& _){
+          [local_subst](Match& _) -> Node {
             auto res = local_subst->find(node_val(_(TVar)));
             if (res != local_subst->end()){
               return (res->second.first)->clone();
             }
-            return NoChange ^ _(TVar); // no substitution found (yet)
+            // TODO: We probably want to report an error if we don't have a substitution here
+            return NoChange; // no substitution found (yet)
         },
+
         // error
-        In(TypeArrow) * T(ForAllTy)[ForAllTy] >> 
+        // TODO: Can this happen? In fuzzing?
+        In(TypeArrow) * T(ForAllTy)[ForAllTy] >>
           [](Match& _){
           return err(_(ForAllTy), "internal error, invalid type substitution");
         }
     }
-  }; 
+  };
   tc.pre(TopExpr, [local_subst](Node ){
-    local_subst->clear(); //clear local subst for each top expr 
-    return 0; 
+    local_subst->clear(); //clear local subst for each top expr
+    return 0;
   });
-  // clean-up after pass 
+
+  // TODO: Pass that replaces TopExpr by its Expr (wf is wf). Replace TypError above with regular Errors
+
+  // clean-up after pass
+  // TODO: See if this can be done as a post instead
   tc.post([](Node n){
       auto program = n->front();
       for(auto ts = program->begin(); ts != program->end(); ts++){
         auto cs = *ts/Constraints;
         auto exp = *ts/Expr;
-        // propagate type errors 
+        // propagate type errors
         for(auto c = cs->begin(); c != cs->end(); c++){
           auto msg = ty_err_msg(*c);
-          exp->push_front(Error << (ErrorMsg ^ msg));
+          exp->push_front(Error << (ErrorMsg ^ msg) << *c);
         }
-        program->replace(*ts,exp); //replace top exprs with exprs 
+        program->replace(*ts,exp); //replace top exprs with exprs
       }
       return 0; });
 

--- a/src/passes/typecheck/solve_constraints.cc
+++ b/src/passes/typecheck/solve_constraints.cc
@@ -44,7 +44,7 @@ namespace miniml
                                        (type[Type] * T(TVar)[TVar])) >>
           [local_subst](Match& _) {
             if(in_type(node_val(_(TVar)), _(Type))) {
-              // TODO: More information in type error
+                // TODO: More information in type error
                 return err(_(EqConstr), "Cannot construct infinite type");
             }
             update_substmap(local_subst, _(TVar), _(Type));
@@ -108,15 +108,11 @@ namespace miniml
   {
     return {
         "cleanup_constraints",
-        check::wf_cleanup_constr,
+        check::wf,
         dir::once | dir::bottomup,
         {
-          T(TopExpr) <<
-            T(Constraints) * T(Let, Expr)[Expr] >>
-              [](Match& _) { return _(Expr); },
-
-          T(Constraints) << Any[Constr] >>
-            [](Match& _) { return err(_(Constr), "Internal error: unhandled constraint"); },
+          T(Constraints) >>
+            [](Match&) { return nothing; },
         }
     };
   }

--- a/src/passes/utils.cc
+++ b/src/passes/utils.cc
@@ -2,16 +2,16 @@
 
 namespace miniml {
   using namespace trieste;
-  using Subst = std::map<std::string,std::pair<Node,std::string>>;
+  using Subst = std::map<std::string, Node>;
 
 int counter = 0;
 
-auto err(const NodeRange& r, const std::string& msg)
+Node err(const NodeRange& r, const std::string& msg)
 {
     return Error << (ErrorMsg ^ msg) << (ErrorAst << r);
 }
 
-auto err(Node node, const std::string& msg)
+Node err(Node node, const std::string& msg)
 {
     return Error << (ErrorMsg ^ msg) << (ErrorAst << node);
 }
@@ -173,7 +173,7 @@ void subst_type(Node ty, std::shared_ptr<Subst> subst_map, std::vector<std::stri
   if (ty->type() == TVar) {
     auto name = node_val(ty);
     if (subst_map->find(name) != subst_map->end()) {
-      ty->parent()->replace(ty, (*subst_map)[name].first);
+      ty->parent()->replace(ty, (*subst_map)[name]);
     }
   } else if (ty->type() == TypeArrow) {
       for (auto& child : *ty) {
@@ -194,18 +194,17 @@ void subst_type(Node ty, std::shared_ptr<Subst> subst_map) {
   subst_type(ty, subst_map, bound);
 }
 
-void update_substmap(std::shared_ptr<Subst> subst, Node tyvar, Node subst_ty, std::string payload){
+void update_substmap(std::shared_ptr<Subst> subst, Node tyvar, Node subst_ty) {
   auto var = node_val(tyvar);
-  (*subst)[var] = std::make_pair(subst_ty,payload); //add substitution
-  for (auto [v,val] : *subst){
-    auto [t,p] = val;
-    if (t->type() != TypeArrow){
-      if (var == node_val(t)){
-        (*subst)[v] = std::make_pair(subst_ty,p);
+  (*subst)[var] = subst_ty; //add substitution
+  for (auto [v,t] : *subst) {
+    if (t->type() != TypeArrow) {
+      if (var == node_val(t)) {
+        (*subst)[v] = subst_ty;
       }
     } else {
       subst_arrow(true, t, var, subst_ty->clone());
-      (*subst)[v] = std::make_pair(t, p);
+      (*subst)[v] = t;
     }
   }
 }

--- a/src/passes/utils.cc
+++ b/src/passes/utils.cc
@@ -21,20 +21,6 @@ std::string node_val(Node node){
     return text;
 }
 
-std::string ty_err_msg(Node c){
-  std::string msg;
-  if ((c)->type() == TypError){
-    auto src_exp = node_val(c); // Type error should have exactly 2 children
-    auto t1 = ((c)->front())->str();
-    auto t2 = ((c)->back())->str();
-    msg = "Cannot match type " + t1 + " with type" + t2 + " in expression " + src_exp;
-  } else {
-    msg = "Internal error: Unexpected " + c->str();
-  }
-  return msg;
-}
-
-
 Node get_type(Node n){
   return n/Type/Type;
 }
@@ -88,7 +74,7 @@ Node get_base_type(Node node)
     }
   }
 
-  Node get_op_type(Node node)
+Node get_op_type(Node node)
   {
     trieste::Token typ = node->type();
     if (typ.in({Add,Mul,Sub})){
@@ -120,17 +106,18 @@ Node inst_constraint(Node ty1, Node ty2, Node origin){
 Node gen_constraint(Node ty1, Node ty2, Node origin){
   return create_constraint(GenConstr,ty1,ty2,node_val(origin));
 }
-  // for convinient lifting to top
-  Node lift_constraint(Node n){
-    return Lift << TopExpr << n;
-  }
 
-  Node lift_constraints(std::vector<Node> nodes){
-    Node lift_constraint = Lift << TopExpr;
-    for(Node n : nodes){
+// for convinient lifting to top
+Node lift_constraint(Node n){
+  return Lift << TopExpr << n;
+}
+
+Node lift_constraints(std::vector<Node> nodes){
+  Node lift_constraint = Lift << TopExpr;
+  for(Node n : nodes){
       lift_constraint << n;
-    }
-    return lift_constraint;
+  }
+  return lift_constraint;
 }
 
 bool contains_var(std::string var, Node ty) {
@@ -242,5 +229,3 @@ Node instantiate(Node ty) {
   }
 }
 }
-
-

--- a/src/passes/utils.hh
+++ b/src/passes/utils.hh
@@ -4,7 +4,7 @@
 namespace miniml
 {
   using namespace ::trieste;
-  using Subst = std::map<std::string, std::pair<Node, std::string>>;
+  using Subst = std::map<std::string, Node>;
 
   //a few helper patterns
   inline const auto expr_binOp = T(Mul,Add,Sub,Equals,LT);
@@ -55,11 +55,11 @@ namespace miniml
 
   bool in_type(std::string var, Node ty);
 
-  void update_substmap(std::shared_ptr<Subst> subst, Node tyvar, Node subst_ty, std::string payload);
+  void update_substmap(std::shared_ptr<Subst> subst, Node tyvar, Node subst_ty);
 
   bool apply_subst(std::shared_ptr<Subst> subst, Node ty);
 
-  bool subst_type(Node ty, std::shared_ptr<Subst>);
+  void subst_type(Node ty, std::shared_ptr<Subst>);
 
   Node generalize(Node ty1);
 

--- a/src/passes/utils.hh
+++ b/src/passes/utils.hh
@@ -8,14 +8,14 @@ namespace miniml
 
   //a few helper patterns
   inline const auto expr_binOp = T(Mul,Add,Sub,Equals,LT);
-  inline const auto expr_keywords = T(If,Then,Else);  
+  inline const auto expr_keywords = T(If,Then,Else);
   inline const auto expr_const = T(Int,True,False);
-  inline const auto type = T(TInt,TBool,TVar,TypeArrow); 
+  inline const auto type = T(TInt,TBool,TVar,TypeArrow);
 
   Node err(const NodeRange &r, const std::string &msg);
 
   Node err(Node node, const std::string &msg);
-  
+
   std::string ty_err_msg(Node n);
 
   std::string node_val(Node node);
@@ -33,7 +33,7 @@ namespace miniml
   Node int_type();
 
   Node arrow_type(Node ty1, Node ty2);
-  
+
   Node forall_type(Node tvars, Node ty);
 
   Node get_base_type(Node node);
@@ -45,7 +45,7 @@ namespace miniml
   Node eq_constraint(Node ty1, Node ty2, Node origin);
   Node inst_constraint(Node ty1, Node ty2, Node origin);
   Node gen_constraint(Node ty1, Node ty2, Node origin);
-  
+
 
   Node lift_constraint(Node n);
 
@@ -58,6 +58,8 @@ namespace miniml
   void update_substmap(std::shared_ptr<Subst> subst, Node tyvar, Node subst_ty, std::string payload);
 
   bool apply_subst(std::shared_ptr<Subst> subst, Node ty);
+
+  bool subst_type(Node ty, std::shared_ptr<Subst>);
 
   Node generalize(Node ty1);
 

--- a/src/passes/utils.hh
+++ b/src/passes/utils.hh
@@ -57,8 +57,6 @@ namespace miniml
 
   void update_substmap(std::shared_ptr<Subst> subst, Node tyvar, Node subst_ty);
 
-  bool apply_subst(std::shared_ptr<Subst> subst, Node ty);
-
   void subst_type(Node ty, std::shared_ptr<Subst>);
 
   Node generalize(Node ty1);

--- a/src/passes/utils.hh
+++ b/src/passes/utils.hh
@@ -16,9 +16,7 @@ namespace miniml
 
   Node err(Node node, const std::string &msg);
 
-  std::string ty_err_msg(Node n);
-
-  std::string node_val(Node node);
+    std::string node_val(Node node);
 
   Node get_type(Node n);
 
@@ -50,8 +48,6 @@ namespace miniml
   Node lift_constraint(Node n);
 
   Node lift_constraints(std::vector<Node> nodes);
-
-  bool in(std::string var, NodeIt from, NodeIt end);
 
   bool in_type(std::string var, Node ty);
 


### PR DESCRIPTION
This PR applies Novel Trieste Features™ to allow splitting the rule when solving constraints into multiple smaller ones, while still allowing it to be a `once` pass. The cleanup of constraints is also done in a separate pass, allowing type errors during constraint solving to be registered as regular `Error` nodes. 